### PR TITLE
fix s905l3a phy probles booting on kernel 6.0.x

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
+++ b/arch/arm64/boot/dts/amlogic/meson-g12-common.dtsi
@@ -181,8 +181,8 @@
 				      "timing-adjustment";
 			rx-fifo-depth = <4096>;
 			tx-fifo-depth = <2048>;
-			resets = <&reset RESET_ETHERNET>;
-			reset-names = "stmmaceth";
+			//resets = <&reset RESET_ETHERNET>;
+			//reset-names = "stmmaceth";
 			status = "disabled";
 
 			mdio0: mdio {


### PR DESCRIPTION
m401a盒子在使用5.15.x内核启动时，网卡正常，在使用6.0.x内核启动时，无法初始网络。对比两种情况的提示，显示在初始网卡phy处异常：
[   23.988640] meson8b-dwmac ff3f0000.ethernet eth0: no phy at addr -1
[   23.996983] meson8b-dwmac ff3f0000.ethernet eth0: __stmmac_open: Cannot attach to PHY (error: -19)

对比了两者的dts文件族的差异，发现6.0.x内核的g12-common.dtsi文件与5.15.内核同名文件存在差异，不知道是否历次修改中遗忘了，注释了其中ethmac里面的两行：
//resets = <&reset RESET_ETHERNET>;
//reset-names = "stmmaceth";

m401a盒子可以正常启动6.0.9内核的网络了。

另似乎这个文件是很多板子的基础，修改影响较大，未知在此次修改是否合适，请斟酌！
